### PR TITLE
fixed bug in index.js

### DIFF
--- a/js/tic-tac-toe/index.js
+++ b/js/tic-tac-toe/index.js
@@ -9,6 +9,7 @@ board.addEventListener("click", ({ target }) => {
   if (classes.includes("tile") && classes.length !== 1) return;
 
   const idx = tiles.indexOf(target);
+  if(idx<0) return;
 
   target.classList.add(`tile-${turn}`);
   symbols[idx % 3][Math.floor(idx / 3)] = turn;


### PR DESCRIPTION
Przy przeciąganiu kratki na kratkę powstaje błąd,
~idx przyjmuje wartość -1
~dalsze działanie nie może zostać wykonane (np. idx % 3) 
~kontener kratek przyjmuje klasę "tile-n" która niszczy cały layout gry